### PR TITLE
Add explicit require to load contentful_model

### DIFF
--- a/lib/contentful_rails.rb
+++ b/lib/contentful_rails.rb
@@ -1,3 +1,6 @@
+require 'redcarpet'
+require 'contentful_model'
+
 require "contentful_rails/engine"
 require "contentful_rails/development_constraint"
 require 'contentful_rails/caching/timestamps'
@@ -5,7 +8,6 @@ require "contentful_rails/markdown_renderer"
 require "contentful_rails/nested_resource"
 require "contentful_rails/sluggable"
 require "contentful_rails/preview"
-require 'redcarpet'
 
 module ContentfulRails
   class << self


### PR DESCRIPTION
Also move redcarpet up so that both external gem requires are done
before the "internal" requires of other files within this gem.

Used ActiveRecord as a model for this, knowing it has several external
requirements as well.

https://github.com/rails/rails/blob/c3133f50bc7b09c945f6387f3a64539b75d3dbc9/activerecord/lib/active_record.rb