### PR TITLE
Updated required rails gem version

### DIFF
--- a/contentful_rails.gemspec
+++ b/contentful_rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "contentful_model", ">= 0.1.7"
-  s.add_dependency "rails", ">= 4.1.8"
+  s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "redcarpet", "~> 3.2"
 
 end


### PR DESCRIPTION
Sluggable requires ```class_methods```

Was first introduced in https://github.com/rails/rails/commit/b16c36e688970df2f96f793a759365b248b582ad